### PR TITLE
Refactor OpenAPI routes to utilize ResourceDescription

### DIFF
--- a/.github/workflows/Linting.yaml
+++ b/.github/workflows/Linting.yaml
@@ -49,6 +49,8 @@ jobs:
     generate-openapi:
         name: Generate OpenAPI document
         runs-on: ubuntu-latest
+        # https://stackoverflow.com/a/74439898
+        if: needs.pr-check.outputs.number == 'null'
         steps:
             - name: Checkout repository
               uses: actions/checkout@v3

--- a/server/src/main/kotlin/routing/v1/apikeys/CreateApiKeyRestController.kt
+++ b/server/src/main/kotlin/routing/v1/apikeys/CreateApiKeyRestController.kt
@@ -32,6 +32,8 @@ import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.models.ApiKeys
 import org.noelware.charted.models.flags.ApiKeyScope
 import org.noelware.charted.models.users.User
+import org.noelware.charted.modules.openapi.kotlin.dsl.created
+import org.noelware.charted.modules.openapi.kotlin.dsl.json
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
 import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.apikeys.ApiKeysDatabaseController
@@ -43,6 +45,8 @@ import org.noelware.charted.server.extensions.putAndRemove
 import org.noelware.charted.server.plugins.sessions.Sessions
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 import kotlin.reflect.typeOf
 import kotlin.time.Duration.Companion.days
 import kotlin.time.DurationUnit
@@ -61,12 +65,12 @@ class CreateApiKeyRestController(private val controller: ApiKeysDatabaseControll
         call.respond(HttpStatusCode.Created, ApiResponse.ok(apikey))
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/apikeys") {
+    companion object: ResourceDescription by describeResource("/apikeys", {
         put {
             description = "Creates an API key under the current authenticated user"
 
             requestBody {
-                contentType(ContentType.Application.Json) {
+                json {
                     schema(
                         CreateApiKeyPayload(
                             "API key to automate some stuff!",
@@ -79,8 +83,8 @@ class CreateApiKeyRestController(private val controller: ApiKeysDatabaseControll
             }
 
             addAuthenticationResponses()
-            response(HttpStatusCode.Created) {
-                contentType(ContentType.Application.Json) {
+            created {
+                json {
                     schema(
                         typeOf<ApiResponse.Ok<ApiKeys>>(),
                         ApiResponse.ok(
@@ -109,5 +113,5 @@ class CreateApiKeyRestController(private val controller: ApiKeysDatabaseControll
                 }
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/apikeys/CreateApiKeyRestController.kt
+++ b/server/src/main/kotlin/routing/v1/apikeys/CreateApiKeyRestController.kt
@@ -22,7 +22,6 @@ import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import io.swagger.v3.oas.models.PathItem
 import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
@@ -35,7 +34,6 @@ import org.noelware.charted.models.users.User
 import org.noelware.charted.modules.openapi.kotlin.dsl.created
 import org.noelware.charted.modules.openapi.kotlin.dsl.json
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.apikeys.ApiKeysDatabaseController
 import org.noelware.charted.modules.postgresql.controllers.apikeys.CreateApiKeyPayload
 import org.noelware.charted.modules.postgresql.ktor.UserEntityAttributeKey

--- a/server/src/main/kotlin/routing/v1/apikeys/DeleteApiKeyController.kt
+++ b/server/src/main/kotlin/routing/v1/apikeys/DeleteApiKeyController.kt
@@ -29,8 +29,7 @@ import org.noelware.charted.ValidationException
 import org.noelware.charted.common.extensions.regexp.matchesNameAndIdRegex
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.models.flags.ApiKeyScope
-import org.noelware.charted.modules.openapi.kotlin.dsl.idOrName
-import org.noelware.charted.modules.openapi.kotlin.dsl.schema
+import org.noelware.charted.modules.openapi.kotlin.dsl.*
 import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.apikeys.ApiKeysDatabaseController
 import org.noelware.charted.modules.postgresql.tables.ApiKeyTable
@@ -39,6 +38,8 @@ import org.noelware.charted.server.extensions.currentUserEntity
 import org.noelware.charted.server.plugins.sessions.Sessions
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 
 class DeleteApiKeyController(private val controller: ApiKeysDatabaseController): RestController("/apikeys/{idOrName}", HttpMethod.Delete) {
     override val apiVersion: APIVersion = APIVersion.V1
@@ -88,22 +89,22 @@ class DeleteApiKeyController(private val controller: ApiKeysDatabaseController):
         call.respond(HttpStatusCode.Accepted, ApiResponse.ok())
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/apikeys/{idOrName}") {
+    companion object: ResourceDescription by describeResource("/apikeys/{idOrName}", {
         delete {
             description = "Deletes an API key resource off the current authenticated user's account"
 
             idOrName()
             addAuthenticationResponses()
-            response(HttpStatusCode.Accepted) {
+            accepted {
                 description = "API key resource was deleted"
-                contentType(ContentType.Application.Json) {
+                json {
                     schema(ApiResponse.ok())
                 }
             }
 
-            response(HttpStatusCode.NotFound) {
+            notFound {
                 description = "API key resource with name or ID was not found"
-                contentType(ContentType.Application.Json) {
+                json {
                     schema(
                         ApiResponse.err(
                             "API_KEY_NOT_FOUND",
@@ -113,5 +114,5 @@ class DeleteApiKeyController(private val controller: ApiKeysDatabaseController):
                 }
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/apikeys/DeleteApiKeyController.kt
+++ b/server/src/main/kotlin/routing/v1/apikeys/DeleteApiKeyController.kt
@@ -22,7 +22,6 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
-import io.swagger.v3.oas.models.PathItem
 import org.jetbrains.exposed.sql.and
 import org.noelware.charted.StringOverflowException
 import org.noelware.charted.ValidationException
@@ -30,7 +29,6 @@ import org.noelware.charted.common.extensions.regexp.matchesNameAndIdRegex
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.models.flags.ApiKeyScope
 import org.noelware.charted.modules.openapi.kotlin.dsl.*
-import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.apikeys.ApiKeysDatabaseController
 import org.noelware.charted.modules.postgresql.tables.ApiKeyTable
 import org.noelware.charted.server.extensions.addAuthenticationResponses

--- a/server/src/main/kotlin/routing/v1/apikeys/GetApiKeysRestController.kt
+++ b/server/src/main/kotlin/routing/v1/apikeys/GetApiKeysRestController.kt
@@ -21,13 +21,11 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import io.swagger.v3.oas.models.PathItem
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.models.ApiKeys
 import org.noelware.charted.modules.openapi.kotlin.dsl.json
 import org.noelware.charted.modules.openapi.kotlin.dsl.ok
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.apikeys.ApiKeysDatabaseController
 import org.noelware.charted.modules.postgresql.tables.ApiKeyTable
 import org.noelware.charted.server.extensions.addAuthenticationResponses

--- a/server/src/main/kotlin/routing/v1/apikeys/GetApiKeysRestController.kt
+++ b/server/src/main/kotlin/routing/v1/apikeys/GetApiKeysRestController.kt
@@ -24,6 +24,8 @@ import io.ktor.server.routing.*
 import io.swagger.v3.oas.models.PathItem
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.models.ApiKeys
+import org.noelware.charted.modules.openapi.kotlin.dsl.json
+import org.noelware.charted.modules.openapi.kotlin.dsl.ok
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
 import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.apikeys.ApiKeysDatabaseController
@@ -33,6 +35,8 @@ import org.noelware.charted.server.extensions.currentUserEntity
 import org.noelware.charted.server.plugins.sessions.Sessions
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 
 class GetApiKeysRestController(private val controller: ApiKeysDatabaseController): RestController("/apikeys") {
     override val apiVersion: APIVersion = APIVersion.V1
@@ -45,16 +49,16 @@ class GetApiKeysRestController(private val controller: ApiKeysDatabaseController
         call.respond(HttpStatusCode.OK, ApiResponse.ok(keys))
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/apikeys") {
+    companion object: ResourceDescription by describeResource("/apikeys", {
         get {
             description = "Returns all of the API key resources created by the current authenticated user"
 
             addAuthenticationResponses()
-            response(HttpStatusCode.OK) {
-                contentType(ContentType.Application.Json) {
-                    schema<ApiResponse.Ok<List<ApiKeys>>>()
+            ok {
+                json {
+                    schema<List<ApiKeys>>()
                 }
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/apikeys/GetSingleApiKeyRestController.kt
+++ b/server/src/main/kotlin/routing/v1/apikeys/GetSingleApiKeyRestController.kt
@@ -25,8 +25,7 @@ import io.ktor.server.util.*
 import io.swagger.v3.oas.models.PathItem
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.models.ApiKeys
-import org.noelware.charted.modules.openapi.kotlin.dsl.idOrName
-import org.noelware.charted.modules.openapi.kotlin.dsl.schema
+import org.noelware.charted.modules.openapi.kotlin.dsl.*
 import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.apikeys.ApiKeysDatabaseController
 import org.noelware.charted.modules.postgresql.controllers.getByIdOrNameOrNull
@@ -35,6 +34,8 @@ import org.noelware.charted.server.extensions.addAuthenticationResponses
 import org.noelware.charted.server.plugins.sessions.Sessions
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 
 class GetSingleApiKeyRestController(private val controller: ApiKeysDatabaseController): RestController("/apikeys/{idOrName}") {
     override val apiVersion: APIVersion = APIVersion.V1
@@ -55,20 +56,20 @@ class GetSingleApiKeyRestController(private val controller: ApiKeysDatabaseContr
         call.respond(HttpStatusCode.OK, ApiResponse.ok(apikey))
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/apikeys/{idOrName}") {
+    companion object: ResourceDescription by describeResource("/apikeys/{idOrName}", {
         get {
             description = "Returns a single API key resource owned by the current authenticated user"
 
             idOrName()
             addAuthenticationResponses()
-            response(HttpStatusCode.OK) {
-                contentType(ContentType.Application.Json) {
-                    schema<ApiResponse.Ok<ApiKeys>>()
+            ok {
+                json {
+                    schema<ApiKeys>()
                 }
             }
 
-            response(HttpStatusCode.NotFound) {
-                contentType(ContentType.Application.Json) {
+            notFound {
+                json {
                     schema(
                         ApiResponse.err(
                             "API_KEY_NOT_FOUND",
@@ -78,5 +79,5 @@ class GetSingleApiKeyRestController(private val controller: ApiKeysDatabaseContr
                 }
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/apikeys/GetSingleApiKeyRestController.kt
+++ b/server/src/main/kotlin/routing/v1/apikeys/GetSingleApiKeyRestController.kt
@@ -22,11 +22,9 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
-import io.swagger.v3.oas.models.PathItem
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.models.ApiKeys
 import org.noelware.charted.modules.openapi.kotlin.dsl.*
-import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.apikeys.ApiKeysDatabaseController
 import org.noelware.charted.modules.postgresql.controllers.getByIdOrNameOrNull
 import org.noelware.charted.modules.postgresql.tables.ApiKeyTable

--- a/server/src/main/kotlin/routing/v1/apikeys/PatchApiKeyRestController.kt
+++ b/server/src/main/kotlin/routing/v1/apikeys/PatchApiKeyRestController.kt
@@ -25,8 +25,7 @@ import io.ktor.server.routing.*
 import io.ktor.server.util.*
 import io.swagger.v3.oas.models.PathItem
 import org.noelware.charted.common.types.responses.ApiResponse
-import org.noelware.charted.modules.openapi.kotlin.dsl.idOrName
-import org.noelware.charted.modules.openapi.kotlin.dsl.schema
+import org.noelware.charted.modules.openapi.kotlin.dsl.*
 import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.apikeys.ApiKeysDatabaseController
 import org.noelware.charted.modules.postgresql.controllers.apikeys.PatchApiKeyPayload
@@ -36,6 +35,8 @@ import org.noelware.charted.server.extensions.addAuthenticationResponses
 import org.noelware.charted.server.plugins.sessions.Sessions
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 
 class PatchApiKeyRestController(private val controller: ApiKeysDatabaseController): RestController("/apikeys/{idOrName}", HttpMethod.Patch) {
     override val apiVersion: APIVersion = APIVersion.V1
@@ -59,26 +60,26 @@ class PatchApiKeyRestController(private val controller: ApiKeysDatabaseControlle
         call.respond(HttpStatusCode.Accepted, ApiResponse.ok())
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/apikeys/{idOrName}") {
+    companion object: ResourceDescription by describeResource("/apikeys/{idOrName}", {
         patch {
             description = "Patches an API key resource with a given name or snowflake ID"
 
             idOrName()
             requestBody {
-                contentType(ContentType.Application.Json) {
+                json {
                     schema<PatchApiKeyPayload>()
                 }
             }
 
             addAuthenticationResponses()
-            response(HttpStatusCode.Accepted) {
-                contentType(ContentType.Application.Json) {
+            accepted {
+                json {
                     schema(ApiResponse.ok())
                 }
             }
 
-            response(HttpStatusCode.NotFound) {
-                contentType(ContentType.Application.Json) {
+            notFound {
+                json {
                     schema(
                         ApiResponse.err(
                             "API_KEY_NOT_FOUND",
@@ -88,5 +89,5 @@ class PatchApiKeyRestController(private val controller: ApiKeysDatabaseControlle
                 }
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/apikeys/PatchApiKeyRestController.kt
+++ b/server/src/main/kotlin/routing/v1/apikeys/PatchApiKeyRestController.kt
@@ -23,10 +23,8 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
-import io.swagger.v3.oas.models.PathItem
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.modules.openapi.kotlin.dsl.*
-import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.apikeys.ApiKeysDatabaseController
 import org.noelware.charted.modules.postgresql.controllers.apikeys.PatchApiKeyPayload
 import org.noelware.charted.modules.postgresql.controllers.getByIdOrNameOrNull

--- a/server/src/main/kotlin/routing/v1/organizations/MainOrganizationsRestController.kt
+++ b/server/src/main/kotlin/routing/v1/organizations/MainOrganizationsRestController.kt
@@ -20,14 +20,16 @@ package org.noelware.charted.server.routing.v1.organizations
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.response.*
-import io.swagger.v3.oas.models.PathItem
 import kotlinx.serialization.Serializable
 import org.noelware.charted.ChartedInfo
 import org.noelware.charted.common.types.responses.ApiResponse
+import org.noelware.charted.modules.openapi.kotlin.dsl.json
+import org.noelware.charted.modules.openapi.kotlin.dsl.ok
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 
 @Serializable
 data class MainOrganizationResponse(
@@ -38,14 +40,14 @@ data class MainOrganizationResponse(
 class MainOrganizationsRestController: RestController("/organizations") {
     override val apiVersion: APIVersion = APIVersion.V1
     override suspend fun call(call: ApplicationCall): Unit = call.respond(HttpStatusCode.OK, ApiResponse.ok(MainOrganizationResponse()))
-    override fun toPathDsl(): PathItem = toPaths("/organizations") {
+    companion object: ResourceDescription by describeResource("/organizations", {
         get {
             description = "Generic entrypoint for the Repositories API"
-            response(HttpStatusCode.OK) {
-                contentType(ContentType.Application.Json) {
+            ok {
+                json {
                     schema(MainOrganizationResponse())
                 }
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/organizations/crud/CreateOrganizationRestController.kt
+++ b/server/src/main/kotlin/routing/v1/organizations/crud/CreateOrganizationRestController.kt
@@ -22,15 +22,15 @@ import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import io.swagger.v3.oas.models.PathItem
 import kotlinx.datetime.LocalDateTime
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.models.flags.ApiKeyScope
 import org.noelware.charted.models.organizations.Organization
 import org.noelware.charted.models.users.User
 import org.noelware.charted.modules.helm.charts.HelmChartModule
+import org.noelware.charted.modules.openapi.kotlin.dsl.accepted
+import org.noelware.charted.modules.openapi.kotlin.dsl.json
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.organizations.CreateOrganizationPayload
 import org.noelware.charted.modules.postgresql.controllers.organizations.OrganizationDatabaseController
 import org.noelware.charted.modules.search.SearchModule
@@ -38,6 +38,8 @@ import org.noelware.charted.server.extensions.addAuthenticationResponses
 import org.noelware.charted.server.plugins.sessions.Sessions
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 
 class CreateOrganizationRestController(
     private val organizations: OrganizationDatabaseController,
@@ -60,13 +62,16 @@ class CreateOrganizationRestController(
         call.respond(HttpStatusCode.Created, ApiResponse.ok(org))
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/organizations") {
+    companion object: ResourceDescription by describeResource("/organizations", {
+        description = "Allows creating an organization."
+
         put {
-            description = "Creates an organization resource"
+            description = "Creates an organization resource with the specified parameters."
 
             requestBody {
                 description = "Payload for creating an organization"
-                contentType(ContentType.Application.Json) {
+
+                json {
                     schema(
                         CreateOrganizationPayload(
                             "Noelware, LLC.",
@@ -78,9 +83,10 @@ class CreateOrganizationRestController(
             }
 
             addAuthenticationResponses()
-            response(HttpStatusCode.Accepted) {
-                description = "Created organization resource"
-                contentType(ContentType.Application.Json) {
+            accepted {
+                description = "Returns the created organization resource."
+
+                json {
                     schema(
                         Organization(
                             true,
@@ -110,5 +116,5 @@ class CreateOrganizationRestController(
                 }
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/organizations/crud/DeleteOrganizationRestController.kt
+++ b/server/src/main/kotlin/routing/v1/organizations/crud/DeleteOrganizationRestController.kt
@@ -22,13 +22,11 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
-import io.swagger.v3.oas.models.PathItem
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.models.flags.ApiKeyScope
 import org.noelware.charted.modules.openapi.kotlin.dsl.accepted
 import org.noelware.charted.modules.openapi.kotlin.dsl.json
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.get
 import org.noelware.charted.modules.postgresql.controllers.organizations.OrganizationDatabaseController
 import org.noelware.charted.server.extensions.addAuthenticationResponses
@@ -37,6 +35,8 @@ import org.noelware.charted.server.plugins.sessions.preconditions.canAccessOrgan
 import org.noelware.charted.server.plugins.sessions.preconditions.canDeleteMetadata
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 
 class DeleteOrganizationRestController(private val organizations: OrganizationDatabaseController): RestController("/organizations/{id}", HttpMethod.Delete) {
     override val apiVersion: APIVersion = APIVersion.V1
@@ -54,7 +54,9 @@ class DeleteOrganizationRestController(private val organizations: OrganizationDa
         call.respond(HttpStatusCode.Accepted, ApiResponse.ok())
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/organizations/{id}") {
+    companion object: ResourceDescription by describeResource("/organizations/{id}", {
+        description = "Allows deleting an organization."
+
         delete {
             description = "Deletes an organization resource"
 
@@ -73,5 +75,5 @@ class DeleteOrganizationRestController(private val organizations: OrganizationDa
                 }
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/organizations/crud/GetSingleOrganizationRestController.kt
+++ b/server/src/main/kotlin/routing/v1/organizations/crud/GetSingleOrganizationRestController.kt
@@ -22,7 +22,6 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
-import io.swagger.v3.oas.models.PathItem
 import kotlinx.datetime.LocalDateTime
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.models.flags.ApiKeyScope
@@ -32,7 +31,6 @@ import org.noelware.charted.modules.openapi.kotlin.dsl.idOrName
 import org.noelware.charted.modules.openapi.kotlin.dsl.json
 import org.noelware.charted.modules.openapi.kotlin.dsl.ok
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.getEntityByIdOrNameOrNull
 import org.noelware.charted.modules.postgresql.controllers.organizations.OrganizationDatabaseController
 import org.noelware.charted.modules.postgresql.extensions.fromEntity
@@ -41,6 +39,8 @@ import org.noelware.charted.server.extensions.currentUser
 import org.noelware.charted.server.plugins.sessions.Sessions
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 
 class GetSingleOrganizationRestController(private val organizations: OrganizationDatabaseController): RestController("/organizations/{idOrName}") {
     override val apiVersion: APIVersion = APIVersion.V1
@@ -86,7 +86,7 @@ class GetSingleOrganizationRestController(private val organizations: Organizatio
         call.respond(HttpStatusCode.OK, ApiResponse.ok(Organization.fromEntity(org)))
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/organizations/{idOrName}") {
+    companion object: ResourceDescription by describeResource("/organizations/{idOrName}", {
         get {
             description = "Grabs an organization resource by its ID or name."
             idOrName()
@@ -123,5 +123,5 @@ class GetSingleOrganizationRestController(private val organizations: Organizatio
                 }
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/organizations/crud/GetUserOrganizationsRestController.kt
+++ b/server/src/main/kotlin/routing/v1/organizations/crud/GetUserOrganizationsRestController.kt
@@ -22,18 +22,16 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
-import io.swagger.v3.oas.models.PathItem
 import kotlinx.datetime.LocalDateTime
 import org.jetbrains.exposed.dao.id.EntityID
 import org.noelware.charted.common.types.responses.ApiResponse
+import org.noelware.charted.models.NameOrSnowflake
 import org.noelware.charted.models.flags.ApiKeyScope
 import org.noelware.charted.models.organizations.Organization
 import org.noelware.charted.models.users.User
-import org.noelware.charted.modules.openapi.NameOrSnowflake
 import org.noelware.charted.modules.openapi.kotlin.dsl.json
 import org.noelware.charted.modules.openapi.kotlin.dsl.ok
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.getByIdOrNameOrNull
 import org.noelware.charted.modules.postgresql.controllers.organizations.OrganizationDatabaseController
 import org.noelware.charted.modules.postgresql.controllers.users.UserDatabaseController
@@ -43,6 +41,8 @@ import org.noelware.charted.server.extensions.currentUser
 import org.noelware.charted.server.plugins.sessions.Sessions
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 import kotlin.reflect.typeOf
 
 class GetUserOrganizationsRestController(
@@ -75,7 +75,7 @@ class GetUserOrganizationsRestController(
         call.respond(HttpStatusCode.OK, ApiResponse.ok(organizations))
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/users/{idOrName}/organizations") {
+    companion object: ResourceDescription by describeResource("/users/{idOrName}/organizations", {
         get {
             description = "Returns all the organizations that a user owns"
 
@@ -122,5 +122,5 @@ class GetUserOrganizationsRestController(
                 }
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/organizations/crud/PatchOrganizationRestController.kt
+++ b/server/src/main/kotlin/routing/v1/organizations/crud/PatchOrganizationRestController.kt
@@ -23,14 +23,12 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
-import io.swagger.v3.oas.models.PathItem
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.models.flags.ApiKeyScope
 import org.noelware.charted.modules.openapi.NameOrSnowflake
 import org.noelware.charted.modules.openapi.kotlin.dsl.accepted
 import org.noelware.charted.modules.openapi.kotlin.dsl.json
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.getByIdOrNameOrNull
 import org.noelware.charted.modules.postgresql.controllers.organizations.OrganizationDatabaseController
 import org.noelware.charted.modules.postgresql.controllers.organizations.PatchOrganizationPayload
@@ -44,6 +42,8 @@ import org.noelware.charted.server.plugins.sessions.preconditions.canAccessOrgan
 import org.noelware.charted.server.plugins.sessions.preconditions.canEditMetadata
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 
 class PatchOrganizationRestController(private val organizations: OrganizationDatabaseController): RestController("/organizations/{idOrName}", HttpMethod.Patch) {
     override val apiVersion: APIVersion = APIVersion.V1
@@ -63,7 +63,7 @@ class PatchOrganizationRestController(private val organizations: OrganizationDat
         call.respond(HttpStatusCode.Accepted)
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/organizations/{idOrName}") {
+    companion object: ResourceDescription by describeResource("/organizations/{idOrName}", {
         patch {
             description = "Patch an organization's metadata"
 
@@ -95,5 +95,5 @@ class PatchOrganizationRestController(private val organizations: OrganizationDat
                 }
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/organizations/repositories/GetAllOrganizationRepositoriesRestController.kt
+++ b/server/src/main/kotlin/routing/v1/organizations/repositories/GetAllOrganizationRepositoriesRestController.kt
@@ -22,12 +22,12 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
-import io.swagger.v3.oas.models.PathItem
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.models.repositories.Repository
 import org.noelware.charted.modules.openapi.kotlin.dsl.idOrName
+import org.noelware.charted.modules.openapi.kotlin.dsl.json
+import org.noelware.charted.modules.openapi.kotlin.dsl.ok
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.getEntityByIdOrNameOrNull
 import org.noelware.charted.modules.postgresql.controllers.organizations.OrganizationDatabaseController
 import org.noelware.charted.modules.postgresql.controllers.repositories.RepositoryDatabaseController
@@ -38,7 +38,8 @@ import org.noelware.charted.server.plugins.sessions.Sessions
 import org.noelware.charted.server.plugins.sessions.preconditions.canAccessOrganization
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
-import kotlin.reflect.typeOf
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 
 class GetAllOrganizationRepositoriesRestController(
     private val organizations: OrganizationDatabaseController,
@@ -75,16 +76,19 @@ class GetAllOrganizationRepositoriesRestController(
         call.respond(HttpStatusCode.OK, ApiResponse.ok(repos))
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/organizations/{idOrName}/repositories") {
+    companion object: ResourceDescription by describeResource("/organizations/{idOrName}/repositories", {
+        description = "Returns all of an organization's repositories."
+
         get {
-            description = "Returns all of an organization's repositories"
+            description = "Returns all of an organization's repositories."
 
             idOrName()
-            response(HttpStatusCode.OK) {
-                contentType(ContentType.Application.Json) {
-                    schema(typeOf<ApiResponse.Ok<List<Repository>>>(), ApiResponse.ok(listOf<Repository>()))
+            ok {
+                description = "A list of repositories within this organization."
+                json {
+                    schema<List<Repository>>()
                 }
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/organizations/repositories/PatchOrganizationRepositoryRestController.kt
+++ b/server/src/main/kotlin/routing/v1/organizations/repositories/PatchOrganizationRepositoryRestController.kt
@@ -23,12 +23,9 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
-import io.swagger.v3.oas.models.PathItem
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.models.flags.ApiKeyScope
-import org.noelware.charted.modules.openapi.kotlin.dsl.idOrName
-import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
+import org.noelware.charted.modules.openapi.kotlin.dsl.*
 import org.noelware.charted.modules.postgresql.controllers.get
 import org.noelware.charted.modules.postgresql.controllers.getByIdOrNameOrNull
 import org.noelware.charted.modules.postgresql.controllers.organizations.OrganizationDatabaseController
@@ -43,6 +40,8 @@ import org.noelware.charted.server.plugins.sessions.preconditions.canAccessRepos
 import org.noelware.charted.server.plugins.sessions.preconditions.canEditMetadata
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 
 class PatchOrganizationRepositoryRestController(
     private val controller: RepositoryDatabaseController,
@@ -77,26 +76,31 @@ class PatchOrganizationRepositoryRestController(
         }
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/organizations/{idOrName}/repositories/{id}") {
+    companion object: ResourceDescription by describeResource("/organizations/{idOrName}/repositories/{id}", {
+        description = "Allows updating a repository based on its ID."
+
         patch {
+            description = "Updates an organization's repository based on its ID."
             idOrName()
             pathParameter {
+                description = "The [Snowflake] ID of the repository being queried."
                 name = "id"
+
                 schema<Long>()
             }
 
             addAuthenticationResponses()
-            response(HttpStatusCode.OK) {
-                contentType(ContentType.Application.Json) {
+            ok {
+                json {
                     schema(ApiResponse.ok())
                 }
             }
 
-            response(HttpStatusCode.NotFound) {
-                contentType(ContentType.Application.Json) {
+            notFound {
+                json {
                     schema<ApiResponse.Err>()
                 }
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/repositories/MainRepositoryRestController.kt
+++ b/server/src/main/kotlin/routing/v1/repositories/MainRepositoryRestController.kt
@@ -20,15 +20,17 @@ package org.noelware.charted.server.routing.v1.repositories
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.response.*
-import io.swagger.v3.oas.models.PathItem
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.noelware.charted.ChartedInfo
 import org.noelware.charted.common.types.responses.ApiResponse
+import org.noelware.charted.modules.openapi.kotlin.dsl.json
+import org.noelware.charted.modules.openapi.kotlin.dsl.ok
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 import kotlin.reflect.typeOf
 
 @Serializable
@@ -42,11 +44,11 @@ data class MainRepositoryResponse(
 class MainRepositoryRestController: RestController("/repositories") {
     override val apiVersion: APIVersion = APIVersion.V1
     override suspend fun call(call: ApplicationCall): Unit = call.respond(HttpStatusCode.OK, ApiResponse.ok(MainRepositoryResponse()))
-    override fun toPathDsl(): PathItem = toPaths("/repositories") {
+    companion object: ResourceDescription by describeResource("/repositories", {
         get {
             description = "Generic entrypoint for the Repositories API"
-            response(HttpStatusCode.OK) {
-                contentType(ContentType.Application.Json) {
+            ok {
+                json {
                     // type information get lost when using ApiResponse.ok() since
                     // ApiResponse.ok([data]) returns ApiResponse, so it gets lost.
                     schema(
@@ -58,5 +60,5 @@ class MainRepositoryRestController: RestController("/repositories") {
                 }
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/repositories/crud/DeleteRepositoryRestController.kt
+++ b/server/src/main/kotlin/routing/v1/repositories/crud/DeleteRepositoryRestController.kt
@@ -22,11 +22,12 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
-import io.swagger.v3.oas.models.PathItem
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.models.flags.ApiKeyScope.Repositories
+import org.noelware.charted.modules.openapi.kotlin.dsl.accepted
+import org.noelware.charted.modules.openapi.kotlin.dsl.json
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
+import org.noelware.charted.modules.openapi.kotlin.dsl.unprocessableEntity
 import org.noelware.charted.modules.postgresql.controllers.get
 import org.noelware.charted.modules.postgresql.controllers.repositories.RepositoryDatabaseController
 import org.noelware.charted.server.extensions.addAuthenticationResponses
@@ -35,6 +36,8 @@ import org.noelware.charted.server.plugins.sessions.preconditions.canAccessRepos
 import org.noelware.charted.server.plugins.sessions.preconditions.canDeleteMetadata
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 
 class DeleteRepositoryRestController(private val controller: RepositoryDatabaseController): RestController("/repositories/{id}", HttpMethod.Delete) {
     override val apiVersion: APIVersion = APIVersion.V1
@@ -67,7 +70,7 @@ class DeleteRepositoryRestController(private val controller: RepositoryDatabaseC
         call.respond(HttpStatusCode.Accepted, ApiResponse.ok())
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/repositories/{id}") {
+    companion object: ResourceDescription by describeResource("/repositories/{id}", {
         delete {
             description = "Deletes a repository"
 
@@ -79,16 +82,16 @@ class DeleteRepositoryRestController(private val controller: RepositoryDatabaseC
             }
 
             addAuthenticationResponses()
-            response(HttpStatusCode.Accepted) {
+            accepted {
                 description = "The repository was deleted successfully"
-                contentType(ContentType.Application.Json) {
+                json {
                     schema(ApiResponse.ok())
                 }
             }
 
-            response(HttpStatusCode.UnprocessableEntity) {
+            unprocessableEntity {
                 description = "If the `id` path parameter couldn't be into a valid Snowflake"
-                contentType(ContentType.Application.Json) {
+                json {
                     schema(
                         ApiResponse.err(
                             "UNABLE_TO_PARSE",
@@ -98,5 +101,5 @@ class DeleteRepositoryRestController(private val controller: RepositoryDatabaseC
                 }
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/repositories/crud/GetSingleRepositoryRestController.kt
+++ b/server/src/main/kotlin/routing/v1/repositories/crud/GetSingleRepositoryRestController.kt
@@ -22,17 +22,19 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
-import io.swagger.v3.oas.models.PathItem
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.models.repositories.Repository
+import org.noelware.charted.modules.openapi.kotlin.dsl.json
+import org.noelware.charted.modules.openapi.kotlin.dsl.ok
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.get
 import org.noelware.charted.modules.postgresql.controllers.repositories.RepositoryDatabaseController
 import org.noelware.charted.server.plugins.sessions.Sessions
 import org.noelware.charted.server.plugins.sessions.preconditions.canAccessRepository
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 
 class GetSingleRepositoryRestController(private val controller: RepositoryDatabaseController): RestController("/repositories/{id}") {
     override val apiVersion: APIVersion = APIVersion.V1
@@ -50,7 +52,7 @@ class GetSingleRepositoryRestController(private val controller: RepositoryDataba
         call.respond(HttpStatusCode.OK, ApiResponse.ok(repo))
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/repositories/{id}") {
+    companion object: ResourceDescription by describeResource("/repositories/{id}", {
         get {
             description = "Returns a repository entity with the given ID. Use the /users/{idOrName}/repos/{repoIdOrName} to fetch a user repository with a ID or name, or /organizations/{idOrName}/repos/{repoIdOrName} to fetch a organization repository with a ID or name"
 
@@ -61,11 +63,11 @@ class GetSingleRepositoryRestController(private val controller: RepositoryDataba
                 schema<String>()
             }
 
-            response(HttpStatusCode.OK) {
-                contentType(ContentType.Application.Json) {
-                    schema<ApiResponse.Ok<Repository>>()
+            ok {
+                json {
+                    schema<Repository>()
                 }
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/repositories/readme/CreateOrPatchRepositoryReadmeRestController.kt
+++ b/server/src/main/kotlin/routing/v1/repositories/readme/CreateOrPatchRepositoryReadmeRestController.kt
@@ -24,17 +24,19 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
 import io.ktor.utils.io.jvm.javaio.*
-import io.swagger.v3.oas.models.PathItem
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.models.flags.ApiKeyScope
+import org.noelware.charted.modules.openapi.kotlin.dsl.accepted
+import org.noelware.charted.modules.openapi.kotlin.dsl.json
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.repositories.RepositoryDatabaseController
 import org.noelware.charted.modules.storage.StorageModule
 import org.noelware.charted.server.plugins.sessions.Sessions
 import org.noelware.charted.server.plugins.sessions.preconditions.canEditMetadata
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 
 class CreateOrPatchRepositoryReadmeRestController(
     private val controller: RepositoryDatabaseController,
@@ -56,7 +58,7 @@ class CreateOrPatchRepositoryReadmeRestController(
         call.respond(HttpStatusCode.Accepted, ApiResponse.ok())
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/repositories/{id}/readme") {
+    companion object: ResourceDescription by describeResource("/repositories/{id}/readme", {
         post {
             description = "Creates or updates a repository's README"
 
@@ -67,12 +69,12 @@ class CreateOrPatchRepositoryReadmeRestController(
                 schema<Long>()
             }
 
-            response(HttpStatusCode.Accepted) {
+            accepted {
                 description = "README was updated successfully"
-                contentType(ContentType.Application.Json) {
+                json {
                     schema(ApiResponse.ok())
                 }
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/repositories/readme/DeleteRepositoryReadmeRestController.kt
+++ b/server/src/main/kotlin/routing/v1/repositories/readme/DeleteRepositoryReadmeRestController.kt
@@ -22,17 +22,19 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
-import io.swagger.v3.oas.models.PathItem
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.models.flags.ApiKeyScope
+import org.noelware.charted.modules.openapi.kotlin.dsl.accepted
+import org.noelware.charted.modules.openapi.kotlin.dsl.json
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.repositories.RepositoryDatabaseController
 import org.noelware.charted.modules.storage.StorageModule
 import org.noelware.charted.server.plugins.sessions.Sessions
 import org.noelware.charted.server.plugins.sessions.preconditions.canDeleteMetadata
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 
 class DeleteRepositoryReadmeRestController(
     private val controller: RepositoryDatabaseController,
@@ -53,7 +55,7 @@ class DeleteRepositoryReadmeRestController(
         call.respond(HttpStatusCode.Accepted, ApiResponse.ok())
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/repositories/{id}/readme") {
+    companion object: ResourceDescription by describeResource("/repositories/{id}/readme", {
         delete {
             description = "Creates or updates a repository's README"
 
@@ -64,12 +66,12 @@ class DeleteRepositoryReadmeRestController(
                 schema<Long>()
             }
 
-            response(HttpStatusCode.Accepted) {
+            accepted {
                 description = "README was updated successfully"
-                contentType(ContentType.Application.Json) {
+                json {
                     schema(ApiResponse.ok())
                 }
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/repositories/readme/GetRepositoryReadmeRestController.kt
+++ b/server/src/main/kotlin/routing/v1/repositories/readme/GetRepositoryReadmeRestController.kt
@@ -22,17 +22,20 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
-import io.swagger.v3.oas.models.PathItem
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.models.flags.ApiKeyScope
+import org.noelware.charted.modules.openapi.kotlin.dsl.json
+import org.noelware.charted.modules.openapi.kotlin.dsl.notFound
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
+import org.noelware.charted.modules.openapi.kotlin.dsl.text
 import org.noelware.charted.modules.postgresql.controllers.repositories.RepositoryDatabaseController
 import org.noelware.charted.modules.storage.StorageModule
 import org.noelware.charted.server.extensions.currentUser
 import org.noelware.charted.server.plugins.sessions.Sessions
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 import org.noelware.charted.server.util.createBodyFromInputStream
 
 class GetRepositoryReadmeRestController(
@@ -82,7 +85,7 @@ class GetRepositoryReadmeRestController(
         call.respond(createBodyFromInputStream(readme, ContentType.Text.Plain))
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/repositories/{id}/readme") {
+    companion object: ResourceDescription by describeResource("/repositories/{id}/readme", {
         get {
             description = "Retrieve a repository's README"
 
@@ -95,17 +98,17 @@ class GetRepositoryReadmeRestController(
 
             response(HttpStatusCode.OK) {
                 description = "README content in Markdown"
-                contentType(ContentType.Text.Plain) {
+                text {
                     schema("# Some Markdown\n> Hopefully...")
                 }
             }
 
-            response(HttpStatusCode.NotFound) {
+            notFound {
                 description = "If a repository wasn't found or if there is no README"
-                contentType(ContentType.Application.Json) {
+                json {
                     schema<ApiResponse.Err>()
                 }
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/repositories/releases/CreateRepositoryReleaseRestController.kt
+++ b/server/src/main/kotlin/routing/v1/repositories/releases/CreateRepositoryReleaseRestController.kt
@@ -25,12 +25,11 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
-import io.swagger.v3.oas.models.PathItem
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.models.flags.ApiKeyScope.Repositories
 import org.noelware.charted.models.repositories.RepositoryRelease
+import org.noelware.charted.modules.openapi.kotlin.dsl.json
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.get
 import org.noelware.charted.modules.postgresql.controllers.repositories.RepositoryDatabaseController
 import org.noelware.charted.modules.postgresql.controllers.repositories.releases.CreateRepositoryReleasePayload
@@ -43,6 +42,8 @@ import org.noelware.charted.server.plugins.sessions.preconditions.canAccessRepos
 import org.noelware.charted.server.plugins.sessions.preconditions.canEditMetadata
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 
 class CreateRepositoryReleaseRestController(
     private val controller: RepositoryReleaseDatabaseController,
@@ -81,7 +82,7 @@ class CreateRepositoryReleaseRestController(
         }
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/repositories/{id}/releases") {
+    companion object: ResourceDescription by describeResource("/repositories/{id}/releases", {
         put {
             description = "Creates a repository release"
 
@@ -94,7 +95,7 @@ class CreateRepositoryReleaseRestController(
 
             requestBody {
                 description = "Payload for creating a repository release"
-                contentType(ContentType.Application.Json) {
+                json {
                     schema(
                         CreateRepositoryReleasePayload(
                             updateText = "# 0.0.1-beta\nSome updates!",
@@ -107,10 +108,10 @@ class CreateRepositoryReleaseRestController(
             addAuthenticationResponses()
             response(HttpStatusCode.Created) {
                 description = "Release resource was created successfully"
-                contentType(ContentType.Application.Json) {
-                    schema<ApiResponse.Ok<RepositoryRelease>>()
+                json {
+                    schema<RepositoryRelease>()
                 }
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/repositories/releases/DeleteRepositoryReleaseRestController.kt
+++ b/server/src/main/kotlin/routing/v1/repositories/releases/DeleteRepositoryReleaseRestController.kt
@@ -25,14 +25,12 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
-import io.swagger.v3.oas.models.PathItem
 import org.jetbrains.exposed.sql.and
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.models.flags.ApiKeyScope
 import org.noelware.charted.modules.helm.charts.HelmChartModule
 import org.noelware.charted.modules.openapi.VersionConstraint
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.repositories.RepositoryDatabaseController
 import org.noelware.charted.modules.postgresql.controllers.repositories.releases.RepositoryReleaseDatabaseController
 import org.noelware.charted.modules.postgresql.tables.RepositoryReleaseTable
@@ -40,6 +38,8 @@ import org.noelware.charted.server.plugins.sessions.Sessions
 import org.noelware.charted.server.plugins.sessions.preconditions.canAccessRepository
 import org.noelware.charted.server.plugins.sessions.preconditions.canDeleteMetadata
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 
 class DeleteRepositoryReleaseRestController(
     private val repositories: RepositoryDatabaseController,
@@ -82,7 +82,7 @@ class DeleteRepositoryReleaseRestController(
         call.respond(HttpStatusCode.Accepted, ApiResponse.ok())
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/repositories/{id}/releases/{version}") {
+    companion object: ResourceDescription by describeResource("/repositories/{id}/releases/{version}", {
         delete {
             description = "Deletes a repository release, and the tarball if it exists"
 
@@ -100,5 +100,5 @@ class DeleteRepositoryReleaseRestController(
                 schema<VersionConstraint>()
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/repositories/releases/GetAllRepositoryReleasesRestController.kt
+++ b/server/src/main/kotlin/routing/v1/repositories/releases/GetAllRepositoryReleasesRestController.kt
@@ -22,7 +22,6 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
-import io.swagger.v3.oas.models.PathItem
 import org.jetbrains.exposed.dao.id.EntityID
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.configuration.kotlin.dsl.Config
@@ -32,7 +31,6 @@ import org.noelware.charted.models.repositories.RepositoryRelease
 import org.noelware.charted.modules.openapi.kotlin.dsl.json
 import org.noelware.charted.modules.openapi.kotlin.dsl.ok
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.get
 import org.noelware.charted.modules.postgresql.controllers.repositories.RepositoryDatabaseController
 import org.noelware.charted.modules.postgresql.controllers.repositories.releases.RepositoryReleaseDatabaseController
@@ -45,6 +43,8 @@ import org.noelware.charted.server.plugins.sessions.preconditions.canAccessRepos
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
 import kotlinx.datetime.LocalDateTime
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 import kotlin.reflect.typeOf
 
 class GetAllRepositoryReleasesRestController(
@@ -79,7 +79,7 @@ class GetAllRepositoryReleasesRestController(
         call.respond(HttpStatusCode.OK, ApiResponse.ok(releases))
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/repositories/{id}/releases") {
+    companion object: ResourceDescription by describeResource("/repositories/{id}/releases", {
         get {
             description = "Retrieve all repository releases"
 
@@ -108,5 +108,5 @@ class GetAllRepositoryReleasesRestController(
                 }
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/repositories/releases/GetRepositoryReleaseChartYamlRestController.kt
+++ b/server/src/main/kotlin/routing/v1/repositories/releases/GetRepositoryReleaseChartYamlRestController.kt
@@ -24,7 +24,6 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
-import io.swagger.v3.oas.models.PathItem
 import org.noelware.charted.ChartedInfo
 import org.noelware.charted.common.types.helm.*
 import org.noelware.charted.common.types.responses.ApiResponse
@@ -32,8 +31,7 @@ import org.noelware.charted.configuration.kotlin.dsl.Config
 import org.noelware.charted.configuration.kotlin.dsl.features.ExperimentalFeature
 import org.noelware.charted.configuration.kotlin.dsl.features.Feature
 import org.noelware.charted.modules.helm.charts.HelmChartModule
-import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
+import org.noelware.charted.modules.openapi.kotlin.dsl.*
 import org.noelware.charted.modules.postgresql.controllers.get
 import org.noelware.charted.modules.postgresql.controllers.repositories.RepositoryDatabaseController
 import org.noelware.charted.server.extensions.addAuthenticationResponses
@@ -42,6 +40,8 @@ import org.noelware.charted.server.plugins.sessions.Sessions
 import org.noelware.charted.server.plugins.sessions.preconditions.canAccessRepository
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 import org.noelware.charted.server.util.createBodyFromInputStream
 
 class GetRepositoryReleaseChartYamlRestController(
@@ -101,7 +101,7 @@ class GetRepositoryReleaseChartYamlRestController(
         call.respond(createBodyFromInputStream(stream, ContentType.parse("text/yaml; charset=utf-8")))
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/repositories/{id}/releases/{version}/Chart.yaml") {
+    companion object: ResourceDescription by describeResource("/repositories/{id}/releases/{version}/Chart.yaml", {
         get {
             description = "Returns the given Chart.yaml file of this release"
             pathParameter {
@@ -126,9 +126,9 @@ class GetRepositoryReleaseChartYamlRestController(
             }
 
             addAuthenticationResponses()
-            response(HttpStatusCode.OK) {
+            ok {
                 description = "Chart.yaml file"
-                contentType(ContentType.parse("text/yaml; charset=utf-8")) {
+                yaml {
                     // This is the actual Chart.yaml for charted-server's Helm chart :)
                     schema(
                         ChartSpec(
@@ -160,9 +160,9 @@ class GetRepositoryReleaseChartYamlRestController(
                 }
             }
 
-            response(HttpStatusCode.BadRequest) {
+            badRequest {
                 description = "If the version path parameter wasn't a valid SemVer version"
-                contentType(ContentType.Application.Json) {
+                json {
                     schema(
                         ApiResponse.err(
                             "INVALID_SEMVER",
@@ -172,10 +172,10 @@ class GetRepositoryReleaseChartYamlRestController(
                 }
             }
 
-            response(HttpStatusCode.NotFound) {
+            notFound {
                 description = "If the Chart.yaml file wasn't found for this release"
-                contentType(ContentType.Application.Json)
+                json()
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/repositories/releases/GetRepositoryReleaseTemplatesRestController.kt
+++ b/server/src/main/kotlin/routing/v1/repositories/releases/GetRepositoryReleaseTemplatesRestController.kt
@@ -24,14 +24,12 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
-import io.swagger.v3.oas.models.PathItem
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.configuration.kotlin.dsl.Config
 import org.noelware.charted.configuration.kotlin.dsl.features.ExperimentalFeature
 import org.noelware.charted.configuration.kotlin.dsl.features.Feature
 import org.noelware.charted.modules.helm.charts.HelmChartModule
-import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
+import org.noelware.charted.modules.openapi.kotlin.dsl.*
 import org.noelware.charted.modules.postgresql.controllers.get
 import org.noelware.charted.modules.postgresql.controllers.repositories.RepositoryDatabaseController
 import org.noelware.charted.server.extensions.addAuthenticationResponses
@@ -40,6 +38,8 @@ import org.noelware.charted.server.plugins.sessions.Sessions
 import org.noelware.charted.server.plugins.sessions.preconditions.canAccessRepository
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 import kotlin.reflect.typeOf
 
 class GetRepositoryReleaseTemplatesRestController(
@@ -95,7 +95,7 @@ class GetRepositoryReleaseTemplatesRestController(
         call.respond(HttpStatusCode.OK, ApiResponse.ok(templates))
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/repositories/{id}/releases/{version}/templates") {
+    companion object: ResourceDescription by describeResource("/repositories/{id}/releases/{version}/templates", {
         get {
             description = "List of all available templates of a given release"
             pathParameter {
@@ -120,9 +120,9 @@ class GetRepositoryReleaseTemplatesRestController(
             }
 
             addAuthenticationResponses()
-            response(HttpStatusCode.OK) {
+            ok {
                 description = "All the templates available"
-                contentType(ContentType.Application.Json) {
+                json {
                     schema(
                         typeOf<ApiResponse.Ok<List<String>>>(),
                         ApiResponse.ok(
@@ -132,9 +132,9 @@ class GetRepositoryReleaseTemplatesRestController(
                 }
             }
 
-            response(HttpStatusCode.BadRequest) {
+            badRequest {
                 description = "If the version path parameter wasn't a valid SemVer version"
-                contentType(ContentType.Application.Json) {
+                json {
                     schema(
                         ApiResponse.err(
                             "INVALID_SEMVER",
@@ -144,10 +144,10 @@ class GetRepositoryReleaseTemplatesRestController(
                 }
             }
 
-            response(HttpStatusCode.NotFound) {
+            notFound {
                 description = "If the tar resource wasn't found"
                 contentType(ContentType.Application.Json)
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/repositories/releases/PatchRepositoryReleaseRestController.kt
+++ b/server/src/main/kotlin/routing/v1/repositories/releases/PatchRepositoryReleaseRestController.kt
@@ -25,7 +25,6 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
-import io.swagger.v3.oas.models.PathItem
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.and
 import org.noelware.charted.common.types.responses.ApiResponse
@@ -37,7 +36,6 @@ import org.noelware.charted.modules.openapi.VersionConstraint
 import org.noelware.charted.modules.openapi.kotlin.dsl.accepted
 import org.noelware.charted.modules.openapi.kotlin.dsl.json
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.get
 import org.noelware.charted.modules.postgresql.controllers.repositories.RepositoryDatabaseController
 import org.noelware.charted.modules.postgresql.controllers.repositories.releases.PatchRepositoryReleasePayload
@@ -49,6 +47,8 @@ import org.noelware.charted.server.plugins.sessions.Sessions
 import org.noelware.charted.server.plugins.sessions.preconditions.canEditMetadata
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 
 class PatchRepositoryReleaseRestController(
     private val repositories: RepositoryDatabaseController,
@@ -106,7 +106,7 @@ class PatchRepositoryReleaseRestController(
         call.respond(HttpStatusCode.Accepted, ApiResponse.ok())
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/repositories/{id}/releases/{version}") {
+    companion object: ResourceDescription by describeResource("/repositories/{id}/releases/{version}", {
         patch {
             description = "Patch a repository release's metadata"
 
@@ -141,5 +141,5 @@ class PatchRepositoryReleaseRestController(
                 }
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/users/crud/GetUserRestController.kt
+++ b/server/src/main/kotlin/routing/v1/users/crud/GetUserRestController.kt
@@ -21,13 +21,10 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.util.*
-import io.swagger.v3.oas.models.PathItem
 import org.noelware.charted.common.extensions.regexp.matchesNameAndIdRegex
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.models.users.User
-import org.noelware.charted.modules.openapi.NameOrSnowflake
 import org.noelware.charted.modules.openapi.kotlin.dsl.*
-import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.EntityNotFoundException
 import org.noelware.charted.modules.postgresql.controllers.get
 import org.noelware.charted.modules.postgresql.controllers.users.UserDatabaseController
@@ -72,38 +69,6 @@ class GetUserRestController(private val controller: UserDatabaseController): Res
                     "Provided idOrName parameter by request was not a valid snowflake or username.",
                 ),
             )
-        }
-    }
-
-    override fun toPathDsl(): PathItem = toPaths("/users/{idOrName}") {
-        get {
-            description = "Retrieves a user from the database"
-            pathParameter {
-                description = "The snowflake or username to use"
-                name = "idOrName"
-
-                schema<NameOrSnowflake>()
-            }
-
-            ok {
-                json {
-                    schema<ApiResponse.Ok<User>>()
-                }
-            }
-
-            badRequest {
-                description = "If the provided idOrName parameter wasn't a snowflake or username"
-                json {
-                    schema<ApiResponse.Err>()
-                }
-            }
-
-            notFound {
-                description = "If a user by the idOrName parameter was not found"
-                json {
-                    schema<ApiResponse.Err>()
-                }
-            }
         }
     }
 

--- a/server/src/main/kotlin/routing/v1/users/crud/PatchUserRestController.kt
+++ b/server/src/main/kotlin/routing/v1/users/crud/PatchUserRestController.kt
@@ -25,6 +25,7 @@ import io.ktor.server.routing.*
 import io.swagger.v3.oas.models.PathItem
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.models.flags.ApiKeyScope
+import org.noelware.charted.modules.openapi.kotlin.dsl.accepted
 import org.noelware.charted.modules.openapi.kotlin.dsl.json
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
 import org.noelware.charted.modules.openapi.toPaths
@@ -69,8 +70,8 @@ class PatchUserRestController(private val controller: UserDatabaseController): R
             }
 
             addAuthenticationResponses()
-            response(HttpStatusCode.Accepted) {
-                contentType(ContentType.Application.Json) {
+            accepted {
+                json {
                     schema(ApiResponse.ok())
                 }
             }

--- a/server/src/main/kotlin/routing/v1/users/repositories/CreateUserRepositoryRestController.kt
+++ b/server/src/main/kotlin/routing/v1/users/repositories/CreateUserRepositoryRestController.kt
@@ -22,13 +22,13 @@ import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import io.swagger.v3.oas.models.PathItem
 import org.noelware.charted.common.types.helm.RepoType
 import org.noelware.charted.common.types.responses.ApiResponse
 import org.noelware.charted.models.flags.ApiKeyScope.Repositories
 import org.noelware.charted.models.repositories.Repository
+import org.noelware.charted.modules.openapi.kotlin.dsl.created
+import org.noelware.charted.modules.openapi.kotlin.dsl.json
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.repositories.CreateRepositoryPayload
 import org.noelware.charted.modules.postgresql.controllers.repositories.RepositoryDatabaseController
 import org.noelware.charted.modules.postgresql.ktor.OwnerIdAttributeKey
@@ -39,6 +39,8 @@ import org.noelware.charted.server.extensions.putAndRemove
 import org.noelware.charted.server.plugins.sessions.Sessions
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 
 class CreateUserRepositoryRestController(
     private val controller: RepositoryDatabaseController,
@@ -60,11 +62,11 @@ class CreateUserRepositoryRestController(
         }
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/users/@me/repositories") {
+    companion object: ResourceDescription by describeResource("/users/@me/repositories", {
         put {
             description = "Creates a repository that is owned by the current authenticated user"
             requestBody {
-                contentType(ContentType.Application.Json) {
+                json {
                     schema(
                         CreateRepositoryPayload(
                             "helm library to provide common stuff",
@@ -78,11 +80,11 @@ class CreateUserRepositoryRestController(
             }
 
             addAuthenticationResponses()
-            response(HttpStatusCode.Created) {
-                contentType(ContentType.Application.Json) {
+            created {
+                json {
                     schema<ApiResponse.Ok<Repository>>()
                 }
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/users/repositories/GetAllUserRepositoriesRestController.kt
+++ b/server/src/main/kotlin/routing/v1/users/repositories/GetAllUserRepositoriesRestController.kt
@@ -22,12 +22,12 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
-import io.swagger.v3.oas.models.PathItem
 import org.noelware.charted.common.types.responses.ApiResponse
+import org.noelware.charted.models.NameOrSnowflake
 import org.noelware.charted.models.repositories.Repository
-import org.noelware.charted.modules.openapi.NameOrSnowflake
+import org.noelware.charted.modules.openapi.kotlin.dsl.json
+import org.noelware.charted.modules.openapi.kotlin.dsl.ok
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.getByIdOrNameOrNull
 import org.noelware.charted.modules.postgresql.controllers.repositories.RepositoryDatabaseController
 import org.noelware.charted.modules.postgresql.controllers.users.UserDatabaseController
@@ -37,6 +37,8 @@ import org.noelware.charted.server.extensions.currentUser
 import org.noelware.charted.server.plugins.sessions.Sessions
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 import kotlin.reflect.typeOf
 
 class GetAllUserRepositoriesRestController(
@@ -72,7 +74,7 @@ class GetAllUserRepositoriesRestController(
         call.respond(HttpStatusCode.OK, ApiResponse.ok(controller.all(RepositoryTable::owner to user.id)))
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/users/{idOrName}/repositories") {
+    companion object: ResourceDescription by describeResource("/users/{idOrName}/repositories", {
         get {
             description = "Returns all of an user's repositories"
 
@@ -81,11 +83,11 @@ class GetAllUserRepositoriesRestController(
                 schema<NameOrSnowflake>()
             }
 
-            response(HttpStatusCode.OK) {
-                contentType(ContentType.Application.Json) {
+            ok {
+                json {
                     schema(typeOf<ApiResponse.Ok<List<Repository>>>(), ApiResponse.ok(listOf<Repository>()))
                 }
             }
         }
-    }
+    })
 }

--- a/server/src/main/kotlin/routing/v1/users/repositories/PatchUserRepositoryRestController.kt
+++ b/server/src/main/kotlin/routing/v1/users/repositories/PatchUserRepositoryRestController.kt
@@ -23,12 +23,13 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.util.*
-import io.swagger.v3.oas.models.PathItem
 import org.noelware.charted.common.types.responses.ApiResponse
+import org.noelware.charted.models.NameOrSnowflake
 import org.noelware.charted.models.flags.ApiKeyScope
-import org.noelware.charted.modules.openapi.NameOrSnowflake
+import org.noelware.charted.modules.openapi.kotlin.dsl.json
+import org.noelware.charted.modules.openapi.kotlin.dsl.notFound
+import org.noelware.charted.modules.openapi.kotlin.dsl.ok
 import org.noelware.charted.modules.openapi.kotlin.dsl.schema
-import org.noelware.charted.modules.openapi.toPaths
 import org.noelware.charted.modules.postgresql.controllers.get
 import org.noelware.charted.modules.postgresql.controllers.getByIdOrNameOrNull
 import org.noelware.charted.modules.postgresql.controllers.repositories.RepositoryDatabaseController
@@ -41,6 +42,8 @@ import org.noelware.charted.server.plugins.sessions.Sessions
 import org.noelware.charted.server.plugins.sessions.preconditions.canEditMetadata
 import org.noelware.charted.server.routing.APIVersion
 import org.noelware.charted.server.routing.RestController
+import org.noelware.charted.server.routing.openapi.ResourceDescription
+import org.noelware.charted.server.routing.openapi.describeResource
 
 class PatchUserRepositoryRestController(
     private val controller: RepositoryDatabaseController,
@@ -72,7 +75,7 @@ class PatchUserRepositoryRestController(
         }
     }
 
-    override fun toPathDsl(): PathItem = toPaths("/users/{idOrName}/repositories/{id}") {
+    companion object: ResourceDescription by describeResource("/users/{idOrName}/repositories/{id}", {
         patch {
             pathParameter {
                 name = "idOrName"
@@ -85,17 +88,17 @@ class PatchUserRepositoryRestController(
             }
 
             addAuthenticationResponses()
-            response(HttpStatusCode.OK) {
-                contentType(ContentType.Application.Json) {
+            ok {
+                json {
                     schema(ApiResponse.ok())
                 }
             }
 
-            response(HttpStatusCode.NotFound) {
-                contentType(ContentType.Application.Json) {
+            notFound {
+                json {
                     schema<ApiResponse.Err>()
                 }
             }
         }
-    }
+    })
 }


### PR DESCRIPTION
This pull request migrates many routes away from the older `toPathDsl` function to the `ResourceDescription` interface. I made a few changes to adopt the newer `json`/`yaml` and `ok`/`notFound`/etc DSL along the way, and slightly tweaked comments in some areas.

This is not quite yet ready to merge, as a few things are remaining:
```
> grep -lr 'toPathDsl' server/src
server/src/main/kotlin/routing/v1/admin/AdminStatsRestController.kt
server/src/main/kotlin/routing/v1/admin/MainAdminRestController.kt
server/src/main/kotlin/routing/v1/users/crud/PatchUserRestController.kt
server/src/main/kotlin/routing/OpenAPI.kt
server/src/main/kotlin/routing/RestController.kt
```

In order to complete the migration, a few things need to be worked out. For reference:
 - For `AdminStatsRestController.kt`, `RestController.kt`, and `MainAdminRestController.kt`, they have a TODO stating that admin endpoints should not be within the OpenAPI document. How should these be migrated?
 - `PatchUserRestController` appears to have an issue regarding `org.apache.commons.validator.routines.EmailValidator` being unavailable from `PatchUserPayload`:
<details>

<summary>Stacktrace</summary>

```
org.koin.core.error.NoBeanDefFoundException: No definition found for class:'org.apache.commons.validator.routines.EmailValidator' q:''. Check your definitions!
	at org.koin.core.scope.Scope.throwDefinitionNotFound(Scope.kt:298)
	at org.koin.core.scope.Scope.resolveValue(Scope.kt:268)
	at org.koin.core.scope.Scope.resolveInstance(Scope.kt:231)
	at org.koin.core.scope.Scope.get(Scope.kt:210)
	at org.noelware.charted.modules.postgresql.controllers.users.PatchUserPayload$special$$inlined$inject$1.getValue(KoinExtensions.kt:66)
	at org.noelware.charted.modules.postgresql.controllers.users.PatchUserPayload._init_$lambda$0(PatchUserPayload.kt:42)
	at org.noelware.charted.modules.postgresql.controllers.users.PatchUserPayload.<init>(PatchUserPayload.kt:65)
	at org.noelware.charted.server.routing.v1.users.crud.PatchUserRestController$Companion$1$1$1$1.invoke(PatchUserRestController.kt:60)
	at org.noelware.charted.server.routing.v1.users.crud.PatchUserRestController$Companion$1$1$1$1.invoke(PatchUserRestController.kt:58)
	at org.noelware.charted.modules.openapi.kotlin.dsl.BodyBuilder.contentType(BodyDsl.kt:69)
	at org.noelware.charted.modules.openapi.kotlin.dsl.BodyDslKt.json(BodyDsl.kt:37)
	at org.noelware.charted.server.routing.v1.users.crud.PatchUserRestController$Companion$1$1$1.invoke(PatchUserRestController.kt:58)
	at org.noelware.charted.server.routing.v1.users.crud.PatchUserRestController$Companion$1$1$1.invoke(PatchUserRestController.kt:57)
	at org.noelware.charted.modules.openapi.kotlin.dsl.OperationDslBuilder.requestBody(OperationDsl.kt:197)
	at org.noelware.charted.server.routing.v1.users.crud.PatchUserRestController$Companion$1$1.invoke(PatchUserRestController.kt:57)
	at org.noelware.charted.server.routing.v1.users.crud.PatchUserRestController$Companion$1$1.invoke(PatchUserRestController.kt:54)
	at org.noelware.charted.modules.openapi.kotlin.dsl.PathDslBuilder.registerMethod(PathDsl.kt:79)
	at org.noelware.charted.modules.openapi.kotlin.dsl.PathDslBuilder.delete(PathDsl.kt:88)
	at org.noelware.charted.server.routing.v1.users.crud.PatchUserRestController$Companion$1.invoke(PatchUserRestController.kt:54)
	at org.noelware.charted.server.routing.v1.users.crud.PatchUserRestController$Companion$1.invoke(PatchUserRestController.kt:53)
	at org.noelware.charted.modules.openapi.ToPathDslKt.toPaths(ToPathDsl.kt:35)
	at org.noelware.charted.server.routing.openapi.ResourceDescriptionKt$describeResource$1.describe(ResourceDescription.kt:42)
	at org.noelware.charted.server.routing.v1.users.crud.PatchUserRestController$Companion.describe(PatchUserRestController.kt)
	at org.noelware.charted.cli.commands.OpenAPICommand.run(OpenAPICommand.kt:112)
	at com.github.ajalt.clikt.parsers.Parser.parse(Parser.kt:198)
	at com.github.ajalt.clikt.parsers.Parser.parse(Parser.kt:211)
	at com.github.ajalt.clikt.parsers.Parser.parse(Parser.kt:18)
	at com.github.ajalt.clikt.core.CliktCommand.parse(CliktCommand.kt:400)
	at com.github.ajalt.clikt.core.CliktCommand.parse$default(CliktCommand.kt:397)
	at com.github.ajalt.clikt.core.CliktCommand.main(CliktCommand.kt:415)
	at com.github.ajalt.clikt.core.CliktCommand.main(CliktCommand.kt:440)
	at org.noelware.charted.cli.CliMainKt.main(main.kt:87)
```

</details>

Once the above changes are resolved, the legacy `toPathDSL` code can (hopefully!) be removed from `OpenAPI.kt`, thus completing the migration.