### PR TITLE
Migrate Bazel to singular URL for http_archive

### DIFF
--- a/build/tools/cc.bzl
+++ b/build/tools/cc.bzl
@@ -19,7 +19,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def charted_cc_repositories():
     http_archive(
         name = "rules_cc",
-        urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.9/rules_cc-0.0.9.tar.gz"],
+        url = "https://github.com/bazelbuild/rules_cc/releases/download/0.0.9/rules_cc-0.0.9.tar.gz",
         sha256 = "2037875b9a4456dce4a79d112a8ae885bbc4aad968e6587dca6e64f3a0900cdf",
         strip_prefix = "rules_cc-0.0.9",
     )

--- a/build/tools/nixpkgs.bzl
+++ b/build/tools/nixpkgs.bzl
@@ -21,5 +21,5 @@ def charted_nixpkgs_repositories():
         name = "io_tweag_rules_nixpkgs",
         sha256 = "c269fa7f70069180e31aa5982313f5a26838db2a6e5f2e9ecbd5941c8c6ceed0",
         strip_prefix = "rules_nixpkgs-ff70910af286a19dbcc109fe36f2e3cb59da78ff",
-        urls = ["https://github.com/tweag/rules_nixpkgs/archive/ff70910af286a19dbcc109fe36f2e3cb59da78ff.tar.gz"],
+        url = "https://github.com/tweag/rules_nixpkgs/archive/ff70910af286a19dbcc109fe36f2e3cb59da78ff.tar.gz",
     )

--- a/build/tools/pkg.bzl
+++ b/build/tools/pkg.bzl
@@ -19,9 +19,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def charted_pkg_repositories():
     http_archive(
         name = "rules_pkg",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz",
-            "https://github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz",
-        ],
+        url = "https://github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz",
         sha256 = "8f9ee2dc10c1ae514ee599a8b42ed99fa262b757058f65ad3c384289ff70c4b8",
     )

--- a/build/tools/protobuf.bzl
+++ b/build/tools/protobuf.bzl
@@ -21,7 +21,5 @@ def charted_protobuf_repositories():
         name = "rules_proto",
         sha256 = "dc3fb206a2cb3441b485eb1e423165b231235a1ea9b031b4433cf7bc1fa460dd",
         strip_prefix = "rules_proto-5.3.0-21.7",
-        urls = [
-            "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
-        ],
+        url = "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
     )

--- a/build/tools/rust.bzl
+++ b/build/tools/rust.bzl
@@ -26,5 +26,5 @@ def charted_rust_repositories():
     http_archive(
         name = "rules_rust",
         sha256 = "9ecd0f2144f0a24e6bc71ebcc50a1ee5128cedeceb32187004532c9710cb2334",
-        urls = ["https://github.com/bazelbuild/rules_rust/releases/download/0.29.1/rules_rust-v0.29.1.tar.gz"],
+        url = "https://github.com/bazelbuild/rules_rust/releases/download/0.29.1/rules_rust-v0.29.1.tar.gz",
     )


### PR DESCRIPTION
Per discussion in #1066, this migrates Bazel to use a singular `url` for the dependency instead of the array of `urls`. This should hopefully resolve issues with Renovate not updating the `sha256` hash of dependencies. Only one dependency specified multiple URLs, and its GitHub version was preferred.