### PR TITLE
Finalize Logstash pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,6 +1343,7 @@ dependencies = [
  "tower-http",
  "tower-layer",
  "tracing",
+ "tracing-appender",
  "tracing-log 0.2.0",
  "tracing-subscriber",
  "utoipa",
@@ -5801,6 +5802,17 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
+dependencies = [
+ "crossbeam-channel",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -22,6 +22,7 @@ use tracing::field::{Field, Visit};
 
 pub mod generic;
 mod json;
+pub mod logstash;
 pub mod server;
 
 static GRAY: ansi_term::Colour = RGB(134, 134, 134);

--- a/crates/logging/src/logstash.rs
+++ b/crates/logging/src/logstash.rs
@@ -1,0 +1,135 @@
+// 🐻‍❄️📦 charted-server: Free, open source, and reliable Helm Chart registry made in Rust
+// Copyright 2022-2023 Noelware, LLC. <team@noelware.org>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{json::JsonVisitor, server::JsonStorage};
+use chrono::Local;
+use serde_json::{json, Value};
+use std::{collections::BTreeMap, io::Write, net::TcpStream, process, thread};
+use tracing::{span, Subscriber};
+use tracing_log::NormalizeEvent;
+use tracing_subscriber::{registry::LookupSpan, Layer};
+
+pub struct LogstashLayer {
+    stream: TcpStream,
+}
+
+impl LogstashLayer {
+    pub fn new(stream: TcpStream) -> LogstashLayer {
+        LogstashLayer { stream }
+    }
+}
+
+impl<S> Layer<S> for LogstashLayer
+where
+    S: Subscriber + for<'l> LookupSpan<'l>,
+{
+    // on new span, we create a `JsonStorage` to record each span data into a `BTreeMap`, which
+    // will be used as the `spans` array.
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let ctx = ctx.clone();
+        let span = ctx.span(id).unwrap();
+        let mut data = BTreeMap::new();
+        let mut visitor = JsonVisitor(&mut data);
+        attrs.record(&mut visitor);
+
+        let storage = JsonStorage(data);
+        span.extensions_mut().insert(storage);
+    }
+
+    fn on_record(&self, span: &span::Id, values: &span::Record<'_>, ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let span = ctx.span(span).unwrap();
+        let mut extensions_mut = span.extensions_mut();
+        let storage: &mut JsonStorage = extensions_mut.get_mut::<JsonStorage>().unwrap();
+        let mut visitor = JsonVisitor(&mut storage.0);
+
+        values.record(&mut visitor);
+    }
+
+    fn on_event(&self, event: &tracing::Event<'_>, ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let thread = thread::current();
+        let pid = process::id();
+        let metadata = event.normalized_metadata();
+        let metadata = metadata.as_ref().unwrap_or_else(|| event.metadata());
+
+        // first, we need to get all span metadata
+        let mut spans = vec![];
+        if let Some(scope) = ctx.event_scope(event) {
+            for span in scope.from_root() {
+                let ext = span.extensions();
+                let storage = ext.get::<JsonStorage>().unwrap();
+                let data = &storage.0;
+
+                spans.push(json!({
+                    // show `null` if there are no fields available
+                    "fields": match data.is_empty() {
+                        true => None,
+                        false => Some(data)
+                    },
+
+                    "target": span.metadata().target(),
+                    "level": metadata.level().as_str().to_lowercase(),
+                    "name": span.metadata().name(),
+                    "meta": json!({
+                        "module": span.metadata().module_path(),
+                        "file": span.metadata().file(),
+                        "line": span.metadata().line(),
+                    })
+                }));
+            }
+        }
+
+        let mut tree = BTreeMap::new();
+        let mut visitor = JsonVisitor(&mut tree);
+        event.record(&mut visitor);
+
+        let message = tree
+            .remove("message")
+            .unwrap_or(Value::String(String::from("{none provided}")));
+
+        let mut stream = &self.stream; // cheap hack that probably works (i dont know lmao)
+        let timestamp = Local::now();
+        let _ = stream.write(
+            serde_json::to_vec(&json!({
+                // common ecs fields that Elastic-senpai wants~! uwu!~
+                "@timestamp": timestamp.to_rfc3339(),
+                "message": message,
+                "labels": json!({
+                    "service": "charted-server",
+                    "vendor": "Noelware, LLC."
+                }),
+
+                // not in the format that Elastic-senpai wants
+                "thread.name": thread.name().unwrap_or("main"),
+                "process.id": pid,
+                "fields": match tree.is_empty() {
+                    true => None,
+                    false => Some(tree),
+                },
+
+                "spans": spans,
+                "meta": json!({
+                    "module": metadata.module_path(),
+                    "file": metadata.file(),
+                    "line": metadata.line(),
+                })
+            }))
+            .unwrap()
+            .as_ref(),
+        );
+
+        // write new-line after
+        let _ = writeln!(stream);
+    }
+}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -72,6 +72,7 @@ tower = { version = "0.4.13", features = ["tracing"] }
 tower-http = { version = "0.4.4", features = ["auth", "cors", "httpdate", "trace", "catch-panic", "limit"] }
 tower-layer = "0.3.2"
 tracing = "0.1.40"
+tracing-appender = "0.2.2"
 tracing-log = "0.2.0"
 tracing-subscriber = "0.3.17"
 utoipa = { version = "4.0.0", features = ["axum_extras", "chrono", "serde_yaml", "uuid"] }


### PR DESCRIPTION
*closes #1097*

This PR brings in a new [`Layer`](https://docs.rs/tracing-subscriber/*/tracing_subscriber/layer/trait.Layer.html) for the tracing-subscriber's `registry` to allow to write any TCP server of the logs that *should* be sent to Logstash.

There is some issues that should be addressed:

* How do we buffer this without blocking execution?
* How do we handle gracefully that the TCP server is closed? Do we open it again? Do we create a Tokio task to check if the TCP server is ok?
* How do we handle invalid JSON? In the initial commit, `.unwrap()` is used heavily when using the `serde_json::json!()` macro.